### PR TITLE
Translation + Drush Make

### DIFF
--- a/webexp.make
+++ b/webexp.make
@@ -6,7 +6,7 @@
 core = 7.x
 api = 2
 projects[drupal][version] = "7.x"
-translations[] = "fr"
+;translations[] = "fr"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Contributed Modules                                           ;


### PR DESCRIPTION
Translation removal from Drush Make till Drush patches problem in windows. Can still use i10n.
