### PR TITLE
Fix to get server's IP address in IIS as well as apache.

### DIFF
--- a/webexp.profile
+++ b/webexp.profile
@@ -190,7 +190,7 @@ function webexp_apps_servers_info() {
       'profile' => $profile,
       'profile_version' => isset($info['version']) ? $info['version'] : '7.x-1.x-dev',
       'server_name' => $_SERVER['SERVER_NAME'],
-      'server_ip' => $_SERVER['SERVER_ADDR'],
+      'server_ip' => gethostbyname($_SERVER['SERVER_NAME']),
     ),
   );
 }


### PR DESCRIPTION
In response to issue #19, fixed to allow the server's IP address to be determined in Microsoft's Internet Information Server as wll as Apache webserver.
