### PR TITLE
fix drush make https

### DIFF
--- a/wetkit.make
+++ b/wetkit.make
@@ -22,7 +22,7 @@ projects[context][type] = module
 projects[ctools][version] = 1.0
 projects[ctools][subdir] = contrib
 projects[ctools][type] = module
-projects[ctools][patch][1444732] = https://drupal.org/files/1444732-exposed-sort-as-pane-config.patch
+projects[ctools][patch][1444732] = http://drupal.org/files/1444732-exposed-sort-as-pane-config.patch
 projects[ctools][patch][1198808] = http://drupal.org/files/1198808-work-around-jquery-bug-with-auto-submit-ctools-1.0.patch
 projects[ctools][patch][1294478] = http://drupal.org/files/1294478-modal-dynamic-mode.patch
 


### PR DESCRIPTION
one of the patch (1444732) is using https, thus causing issue as the drupal.org SSL certificate is not valid for bare drupal.org

ERROR: certificate common name `*.drupal.org' doesn't match requested host name`drupal.org'.

this patch just change the line to use http instead of https (all other patches are using http)
