### PR TITLE
Updated CTools to v1.1 - Issue #204

### DIFF
--- a/wetkit.make
+++ b/wetkit.make
@@ -19,6 +19,7 @@ projects[context][version] = 3.0-beta2
 projects[context][subdir] = contrib
 projects[context][type] = module
 
+; http://drupal.org/node/1719548
 projects[ctools][version] = 1.1
 projects[ctools][subdir] = contrib
 projects[ctools][type] = module


### PR DESCRIPTION
Fix for Issued #204.

Updated the make file to use Ctools 1.1. Two of the previous patches are now included in v1.1, but one patch remains.
