### PR TITLE
Broken link fixes

### DIFF
--- a/modules/apps/wetkit_wetboew/wetkit_wetboew.box.inc
+++ b/modules/apps/wetkit_wetboew/wetkit_wetboew.box.inc
@@ -52,8 +52,8 @@ function wetkit_wetboew_default_box() {
             <p>The&nbsp;Honourable<br />
             <strong>minister name</strong></p>
             <ul>
-                <li><a href="minister">About the minister</a></li>
-                <li><a href="minister/portfolio">His portfolio</a></li>
+                <li><a href="#">About the minister</a></li>
+                <li><a href="#">His portfolio</a></li>
             </ul>
 	</div>
 </div>
@@ -71,8 +71,8 @@ function wetkit_wetboew_default_box() {
             <p>L&#39;honorable<br />
             <strong>nom du minist&egrave;re</strong></p>
             <ul>
-                <li><a href="minister">A propos de la ministre</a></li>
-                <li><a href="minister/portfolio">Son portefeuille</a></li>
+                <li><a href="#">A propos de la ministre</a></li>
+                <li><a href="#">Son portefeuille</a></li>
             </ul>
 	</div>
 </div>
@@ -133,8 +133,8 @@ function wetkit_wetboew_default_box() {
 	<p>This section is for video related content. Often this is the best place to introduce your department or organization.</p>
 </div>
 <ul class="list-bullet-none indent-none">
-    <li><a href="multimedia/help">Multimedia Help</a></li>
-    <li><a href="transcripts">Transcripts and Alternative Formats</a></li>
+    <li><a href="#">Multimedia Help</a></li>
+    <li><a href="#">Transcripts and Alternative Formats</a></li>
 </ul>
 ',
       'format' => 'wetkit_wysiwyg_text',
@@ -147,8 +147,8 @@ function wetkit_wetboew_default_box() {
 	<p>Cette section est pour le contenu vid&eacute;o li&eacute;. Souvent c&#39;est le meilleur endroit pour introduire votre minist&egrave;re ou organisme.</p>
 </div>
 <ul class="list-bullet-none indent-none">
-    <li><a href="multimedia/help">Aide multim&eacute;dia</a></li>
-    <li><a href="transcripts">Les transcriptions et les formats de rechange</a></li>
+    <li><a href="#">Aide multim&eacute;dia</a></li>
+    <li><a href="#">Les transcriptions et les formats de rechange</a></li>
 </ul>
 ',
       'format' => 'wetkit_wysiwyg_text',


### PR DESCRIPTION
Hi,

I ran a broken link crawl on http://wet.openplus.ca/eng earlier and got a couple of hits on placeholder links. Since the wet-boew repository's counterparts to those links are set up to point to "#", I figured it may be for the best to change the Drupal variant's versions of those links to also point towards "#".

**PS:** The following two files appear to be missing from openplus.ca (they were recently re-implemented into the wet-boew repository):
- http://wet.openplus.ca/sites/all/libraries/wet-boew/build/grids/images/drive-download.png
- http://wet.openplus.ca/sites/all/libraries/wet-boew/build/js/css/scrim.png

Thanks :).
