### PR TITLE
WetKit Search + Caption Filter Fixes + Overlay

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -40,7 +40,7 @@ projects[panopoly_widgets][download][branch] = 7.x-1.x
 projects[panopoly_admin][version] = 1.x-dev
 projects[panopoly_admin][subdir] = panopoly
 projects[panopoly_admin][download][type] = git
-projects[panopoly_admin][download][revision] = d00ec1c
+projects[panopoly_admin][download][revision] = 6ca4ae9
 projects[panopoly_admin][download][branch] = 7.x-1.x
 projects[panopoly_admin][patch][1784676] = http://drupal.org/files/remove-simplified-menu-1784676-17.patch
 

--- a/modules/custom/wetkit_search/wetkit_search.make
+++ b/modules/custom/wetkit_search/wetkit_search.make
@@ -5,12 +5,13 @@ core = 7.x
 
 ; Search API and Facet API Modules
 
-projects[facetapi][version] = 1.1
+projects[facetapi][version] = 1.2
 projects[facetapi][subdir] = contrib
 
 projects[search_api][version] = 1.3
 projects[search_api][subdir] = contrib
 projects[search_api][patch][1698098] = http://drupal.org/files/search-api-disabled-index-configure-link.patch
+projects[search_api][patch][1827272] = http://drupal.org/files/1827272-request-path.patch
 
 projects[search_api_solr][version] = 1.0-rc2
 projects[search_api_solr][subdir] = contrib

--- a/modules/custom/wetkit_wysiwyg/wetkit_wysiwyg.make
+++ b/modules/custom/wetkit_wysiwyg/wetkit_wysiwyg.make
@@ -25,7 +25,7 @@ projects[linkit][subdir] = contrib
 
 projects[caption_filter][version] = 1.2
 projects[caption_filter][subdir] = contrib
-projects[caption_filter][patch][1432092] = http://drupal.org/files/caption-button-and-image-1432092-7.patch
+projects[caption_filter][patch][1432092] = http://drupal.org/files/caption-button-and-image-1432092-8_0.patch
 
 ; Include our Editors
 

--- a/wetkit.info
+++ b/wetkit.info
@@ -20,10 +20,10 @@ dependencies[] = block
 dependencies[] = dblog
 dependencies[] = update
 dependencies[] = shortcut
+dependencies[] = overlay
 
 ; Drupal Core Disabled
 ;dependencies[] = help
-;dependencies[] = overlay
 ;dependencies[] = contextual
 ;dependencies[] = rdf
 ;dependencies[] = statistics


### PR DESCRIPTION
A few fixes WetKit Search + Caption Filter needing a lang/fr.js file.

Additionally Overlay has creeped back in based on the following:

Drupal newbies sometimes have difficulty navigating a Drupal site. Overlay attempts to address this by maintaining non-admin context separately, so the user can easily return to the content they were viewing before they entered the admin interface.

Newbies also sometimes don't understand which parts of their site will be publicly visible. Overlay shows admin pages in a visually distinct interface, to make it clear which pages are only visible to admins.

Experienced site builders and developers can easily disable the overlay, but newbies wouldn't even know it exists or how to enable it unless it is already enabled by default.
