### PR TITLE
Travis CI + D.O Packaging Standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,17 @@
 # Ignore Development Files
 .DS_Store
+compass_app_log.txt
+.sass-cache/
 
 # Ignore Contributed Modules
-/modules/contrib/*
-/modules/experimental/*
+/modules/contrib/
+/modules/panopoly/
 
 # Ignore Contributed Libraries
-/libraries/*
+/libraries/
 
 # Ignore Contributed Themes
-/themes/adaptivetheme
-/themes/genesis
-/themes/mobile_jquery
-/themes/rubik
-/themes/tao
-/themes/zen
-
-# SCSS + Compass Development Files
-/themes/web_usability_zen/.sass-cache/
-/themes/wetkit_adaptivetheme/.sass-cache/
-compass_app_log.txt
-/modules/custom/wetkit_wetboew/.sass-cache/
-/modules/custom/wetkit_demo/.sass-cache/
-/modules/custom/wetkit_widgets/.sass-cache/
-/modules/custom/wetkit_wysiwyg/.sass-cache/
-/.sass-cache/
-/themes/wetkit_rubik/.sass-cache/
+/themes/adaptivetheme/
+/themes/responsive_bartik/
+/themes/rubik/
+/themes/tao/

--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ If you do not wish to perform a build out of Drupal yourself (instructions below
 > 3. Install Git 1.7.10 or higher (Some lower versions of git do not apply patches from the make file with Drush Make):
 >   * a) Linux, Mac OSX: http://code.google.com/p/git-osx-installer/
 >   * b) Windows: http://msysgit.github.com/
+> 4. Clone this repository into a tmp directory using the following commands on the Git Bash command prompt.
+<pre>
+git clone https://github.com/wet-boew/wet-boew-drupal.git $tmpdir/wet-boew-drupal;
+</pre>
 > 4. Build the complete Drupal installation software profile in your Web Server DOCROOT using the following commands on the Git Bash command prompt.
 <pre>
-git clone https://github.com/wet-boew/wet-boew-drupal.git profiles/wetkit;
-</pre>
-<pre>
-Command: drush make --prepare-install --no-gitinfofile --working-copy profiles/wetkit/build-wetkit.make &lt;directory_name&gt; -v --debug
-Example: drush make --prepare-install --no-gitinfofile --working-copy profiles/wetkit/build-wetkit.make --yes
+Command: drush make --prepare-install --no-gitinfofile --working-copy $tmpdir/wet-boew-drupal/build-wetkit.make $DOCROOT -v --debug
+Example: drush make --prepare-install --no-gitinfofile --working-copy $tmpdir/wet-boew-drupal/build-wetkit.make /var/www/html --yes
 </pre>
 > 5. To quickly install using the Drush command line, change to the directory where Drupal (for example /var/www/html) was installed and enter this command.
 > Be sure to use a password that meets the password policy for WET.

--- a/build-wetkit.make
+++ b/build-wetkit.make
@@ -4,5 +4,9 @@ core = 7.x
 projects[drupal][version] = 7.19
 includes[] = drupal-org-core.make
 includes[] = drupal-org.make
-
-; Will switch to non in place method and D.O standard shortly
+	
+; Add wetkit to the full Drupal distro build
+projects[wetkit][type] = profile
+projects[wetkit][download][type] = git
+projects[wetkit][download][url] = https://github.com/wet-boew/wet-boew-drupal.git
+projects[wetkit][download][revision] = master

--- a/build-wetkit.make
+++ b/build-wetkit.make
@@ -5,7 +5,7 @@ projects[drupal][version] = 7.19
 includes[] = drupal-org-core.make
 includes[] = drupal-org.make
 	
-; Add wetkit to the full Drupal distro build
+; Drupal.org Packaging Standard
 projects[wetkit][type] = profile
 projects[wetkit][download][type] = git
 projects[wetkit][download][url] = https://github.com/wet-boew/wet-boew-drupal.git

--- a/build-wetkit.make
+++ b/build-wetkit.make
@@ -3,7 +3,6 @@ core = 7.x
 
 projects[drupal][version] = 7.19
 includes[] = drupal-org-core.make
-includes[] = drupal-org.make
 	
 ; Drupal.org Packaging Standard
 projects[wetkit][type] = profile

--- a/build-wetkit.make
+++ b/build-wetkit.make
@@ -4,7 +4,7 @@ core = 7.x
 projects[drupal][version] = 7.19
 includes[] = drupal-org-core.make
 	
-; Drupal.org Packaging Standard
+; Drupal.org packaging standard
 projects[wetkit][type] = profile
 projects[wetkit][download][type] = git
 projects[wetkit][download][url] = https://github.com/wet-boew/wet-boew-drupal.git

--- a/build-wetkit.make
+++ b/build-wetkit.make
@@ -4,7 +4,7 @@ core = 7.x
 projects[drupal][version] = 7.19
 includes[] = drupal-org-core.make
 	
-; Drupal.org packaging standard
+; Drupal.org packaging standards
 projects[wetkit][type] = profile
 projects[wetkit][download][type] = git
 projects[wetkit][download][url] = https://github.com/wet-boew/wet-boew-drupal.git

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -11,5 +11,4 @@ phpenv rehash
 
 # Install WetKit Distribution
 workspace=`pwd`
-git_commit=`git show --pretty=%P HEAD | head -1 | cut -d\  -f 2`
-cat $workspace/build-wetkit.make | sed "s/master/$TRAVIS_COMMIT/g" | drush make --prepare-install php://stdin $workspace/build
+cat $workspace/build-wetkit.make | sed "s/master/$TRAVIS_COMMIT/g" | sed "s/wet-boew\/wet-boew-drupal/$TRAVIS_REPO_SLUG/g" | drush make --prepare-install php://stdin $workspace/build

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -11,5 +11,5 @@ phpenv rehash
 
 # Install WetKit Distribution
 workspace=`pwd`
-git_commit=`git show --pretty=%P HEAD | head -1 | cut -d\  -f 1`
+git_commit=`git show --pretty=%P HEAD | head -1 | cut -d\  -f 2`
 cat $workspace/build-wetkit.make | sed "s/master/$git_commit/g" | drush make --prepare-install php://stdin $workspace/build

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -12,4 +12,4 @@ phpenv rehash
 # Install WetKit Distribution
 workspace=`pwd`
 git_commit=`git show --pretty=%P HEAD | head -1 | cut -d\  -f 2`
-cat $TRAVIS_BUILD_DIR/build-wetkit.make | sed "s/master/$TRAVIS_COMMIT/g" | drush make --prepare-install php://stdin $TRAVIS_BUILD_DIR/build
+cat $workspace/build-wetkit.make | sed "s/master/$TRAVIS_COMMIT/g" | drush make --prepare-install php://stdin $workspace/build

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -9,13 +9,8 @@ pear channel-discover pear.drush.org
 pear install drush/drush-5.8.0
 phpenv rehash
 
-# Install WetKit Distro
-cd ..
-mkdir profiles
-mv wet-boew-drupal wetkit
-mv wetkit profiles/
-mkdir drupal_wet
-mv profiles drupal_wet/
-cd drupal_wet
-drush make --prepare-install profiles/wetkit/build-wetkit.make --yes
-sudo chmod -R 777 sites/all/modules
+# Install WetKit Distribution
+sudo chmod -R 777 /home/travis/.drush/
+workspace=`pwd`
+git_commit=`git show --pretty=%P HEAD | head -1 | cut -d\  -f 1`
+cat $workspace/build-wetkit.make | sed "s/master/$git_commit/g" | drush make --prepare-install php://stdin $workspace/build

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -12,4 +12,4 @@ phpenv rehash
 # Install WetKit Distribution
 workspace=`pwd`
 git_commit=`git show --pretty=%P HEAD | head -1 | cut -d\  -f 2`
-cat $workspace/build-wetkit.make | sed "s/master/$git_commit/g" | drush make --prepare-install php://stdin $workspace/build
+cat $TRAVIS_BUILD_DIR/build-wetkit.make | sed "s/master/$TRAVIS_COMMIT/g" | drush make --prepare-install php://stdin $TRAVIS_BUILD_DIR/build

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -11,4 +11,4 @@ phpenv rehash
 
 # Install WetKit Distribution
 workspace=`pwd`
-cat $workspace/build-wetkit.make | sed "s/master/$TRAVIS_COMMIT/g" | sed "s/wet-boew\/wet-boew-drupal/$TRAVIS_REPO_SLUG/g" | drush make --prepare-install php://stdin $workspace/build
+cat $workspace/build-wetkit.make | sed "s@master@$TRAVIS_COMMIT@g" | sed "s@wet-boew/wet-boew-drupal@$TRAVIS_REPO_SLUG@g" | drush make --prepare-install php://stdin $workspace/build

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -10,7 +10,6 @@ pear install drush/drush-5.8.0
 phpenv rehash
 
 # Install WetKit Distribution
-sudo chmod -R 777 /home/travis/.drush/
 workspace=`pwd`
 git_commit=`git show --pretty=%P HEAD | head -1 | cut -d\  -f 1`
 cat $workspace/build-wetkit.make | sed "s/master/$git_commit/g" | drush make --prepare-install php://stdin $workspace/build

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -2,6 +2,9 @@
 # Travis Testing Script for CI Testing
 
 # Drush SI Drupal
+sleep 5
+cd build
+workspace=`pwd`
 drush si wetkit wetkit_wetboew_selection_form.theme=wetkit_adaptivetheme --sites-subdir=default --db-url=mysql://root:@127.0.0.1/wetkit_db --account-name=admin --account-pass=WetKit@2012 --site-mail=admin@example.com --site-name="Web Experience Toolkit" --yes
 drush cc all --yes
 
@@ -12,16 +15,15 @@ sh -e /etc/init.d/xvfb start
 sleep 3 # give xvfb some time to start
 drush runserver --server=builtin 8080 &
 sleep 3 # give xvfb some time to rebuild
-cd ../../..
+cd ..
 
 # Install + Run CasperJS Testing Suite
 git clone git://github.com/n1k0/casperjs.git
 cd casperjs
 git checkout tags/0.6.10
 cd ..
-DISPLAY=:99.0 ./casperjs/bin/casperjs test drupal_wet/profiles/wetkit/tests/casperjs/
+DISPLAY=:99.0 ./casperjs/bin/casperjs test $workspace/profiles/wetkit/tests/casperjs/
 
 # Install + Run Selenium Testing Suite
 wget http://selenium.googlecode.com/files/selenium-server-standalone-2.15.0.jar
-java -jar selenium-server-standalone-2.15.0.jar -htmlSuite "*chrome" "http://127.0.0.1:8080" "drupal_wet/profiles/wetkit/tests/selenium/WetKitTestSuite.html" "drupal_wet/profiles/wetkit/tests/selenium/Result.html"
-
+java -jar selenium-server-standalone-2.15.0.jar -htmlSuite "*chrome" "http://127.0.0.1:8080" "$workspace/profiles/wetkit/tests/selenium/WetKitTestSuite.html" "$workspace/profiles/wetkit/tests/selenium/Result.html"


### PR DESCRIPTION
So this project has finally received approval to go on Drupal.org so now supporting both D.O packaging standards and Travis CI has become a priority.

``` info
api = 2
core = 7.x

projects[drupal][version] = 7.19
includes[] = drupal-org-core.make
includes[] = drupal-org.make

; Add wetkit to the full Drupal distro build
projects[wetkit][type] = profile
projects[wetkit][download][type] = git
projects[wetkit][download][url] = https://github.com/wet-boew/wet-boew-drupal.git
projects[wetkit][download][revision] = master
```

Notice the problem? The only way to have the CI system (Travis) to be able to re-deploy the site at any point (particularly for pull requests) is to manually include the commit sha (hash) of the current commit in that commit itself. Unfortunately you can't know the current commit until after you've committed it. However we do want this file in version control so that everything we need to build the site is in the repo.

The trick to this is that we can bash script it so that the CI system in this case Travis rewrites the build-projectname.make file on the fly, substituting in the commit sha (hash) in question after cloning the repo to get the proper build-projectname.make that we need to run. So on a merge pull request we want to replace master with the following sha referencing the image below (<del>in red border</del>) Actually should be the corresponding parent sha next to red border.

![PullRequest](https://f.cloud.github.com/assets/984304/137037/b6657cb2-715f-11e2-8c42-c9dc64c70d00.JPG)

We can get the sha and send to drush make using the following script:

``` bash
git_commit=`git show --pretty=%P HEAD | head -1 | cut -d\  -f 1`
cat $workspace/build-wetkit.make | sed "s/master/$git_commit/g" | drush make --prepare-install php://stdin $workspace/build
```

The problem is that Drush behavior is inconsistent and also seems to be doubling operations such as git cloning the same repo twice when this is done. Unfortunately I am at a loss for what is going on at this point. Sometimes if I run the pull request again Drush succeeds other times it fails. Though in all cases it seems Drush is doubling the git cloning of projects, getting translations or patches for different projects on every run. I am at a loss of where to go next to support D.O packaging standards and Travis CI. Perhaps a problem with php://stdin?

You can see some builds below: 

Before this Pull Request:
[Travis Succeeding](https://travis-ci.org/wet-boew/wet-boew-drupal/builds/4634237)

Using this Pull Request
[Travis Build sometimes Failing + Doubling](https://travis-ci.org/wet-boew/wet-boew-drupal/builds/4650184)

This is really important to solve quickly because once we use the Drupal.org packaging standards the build out of contrib modules occurs in profiles/ instead of /sites/all.

@patcon @timeisenhuth @technosophos @travis-ci @populist @msonnabaum @weitzman @LaurentGoderre @MichaelClift @StephenOTT @pjackson28 @mgifford 

Sorry for the barrage of people but hoping someone would have a solution to this. I am still unsure if this is a problem with Travis or Drush.
