### PR TITLE
Update build-wetkit-github.make

### DIFF
--- a/build-wetkit-github.make
+++ b/build-wetkit-github.make
@@ -6,5 +6,5 @@ includes[] = drupal-org-core.make
 
 projects[wetkit][type] = profile
 projects[wetkit][download][type] = git
-projects[wetkit][download][url] = https://github.com/wet-boew/wet-boew-drupal.git
+projects[wetkit][download][url] = http://github.com/wet-boew/wet-boew-drupal.git
 projects[wetkit][download][branch] = 7.x-1.x


### PR DESCRIPTION
When building from f7wcmsstageb1 , https proxy was not configured and https could not work,  http from github works, why not use http instead of https?  http is lower overhead and faster.
