### PR TITLE
force composer to use 1.x - Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,7 +134,7 @@ postgres:
   encoding: utf8
 
 before_install:
-  - composer self-update
+  - composer self-update --1
   - composer global require "lionsad/drupal_ti:1.4.4"
   - drupal-ti before_install
 


### PR DESCRIPTION
Composer was recently upgraded to 2.x, composer people upstream are forcing upgrades to 2.x but there's issues with this update, so temporary solution is to force 1.x using the '--1' flag option on composer self update.  

see https://www.drupal.org/project/wetkit/issues/3183997#comment-13911763

AND

https://getcomposer.org/doc/03-cli.md

AND

https://github.com/LionsAd/drupal_ti/issues/8